### PR TITLE
Introduce a `permit_broadcast_of_discord_messages` Config Option to Toggle Observe-Only Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ plugins/**/__pycache__/
 plugins/gpt-config.yml
 meshlinkvenv/
 .venv/
+mise.toml
 plugins/gpt-config-example.yml
 plugins-disabled/gpt-config-example.yml
 plugins/gpt.py

--- a/config-example.yml
+++ b/config-example.yml
@@ -8,7 +8,7 @@ check_for_updates: True # set to False to disable update checking
 ### DISCORD SETTINGS
 use_discord: True
 max_message_length: 200 # max discord -> mesh message length and info message length
-info_channel_ids: [ 1234567890 ] # seperate using commas 
+info_channel_ids: [ 1234567890 ] # separate using commas
 message_channel_ids: [ 1234567890 ]
 secondary_channel_message_ids: [ ] # secondary channels to send and receive messages from. Each discord channel id in this list corresponds to a node's channel id 1-7.
 token: "SDFjLKJVLREkjslRVJRLKjVLRKJLRVjrLKVJ" # discord bot token - DO NOT SHARE
@@ -17,13 +17,14 @@ ignore_self: True # dont show your own node on discord
 send_packets: True # show all data not just messages
 ping_on_messages: True # should the bot add the message_role to the message
 message_role: "@here" # the role on discord to ping on messages, if you dont want to ping everyone set to a custom role
+permit_broadcast_of_discord_messages: True # allow messages from discord to be transmitted to your selected channel
 send_mesh_commands_to_discord: True # send responses to mesh commands to discord
 
 ### MESH AND RADIO SETTINGS
 prefix: "$" # mesh command prefix
 use_serial: True # set to False if using tcp
 radio_ip: "192.168.1.100" # ip of the radio if using tcp
-send_channel_index: 0 # the index of the channel to send messages on 
+send_channel_index: 0 # the index of the channel to send messages on
 verbose_packets: False # should the full packet data be shown in the console
 send_start_stop: True # should the meshlink announcement be sent on connection and shut down
 include_username_prefix: True # include the username prefix in mesh messages from discord

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def handler(signum, frame):
     if(cfg.config["send_start_stop"]):
         interface.sendText("MeshLink is now stopping!",channelIndex = cfg.config["send_channel_index"])
     exit(1)
- 
+
 signal.signal(signal.SIGINT, handler)
 
 with open("./config.yml",'r') as file:
@@ -116,7 +116,7 @@ def onReceive(packet, interface):
             inst.onReceive(packet,interface,client)
     for cmd in LibCommand.commands:
         cmd.onReceive(packet,interface,client)
-    
+
 def onDisconnect(interface):
     for p in Base.plugins:
         inst = p()
@@ -133,7 +133,7 @@ def init_radio():
     logger.info("Connecting to node...")
     if (cfg.config["use_serial"]):
         interface = SerialInterface()
-        
+
     else:
         interface = TCPInterface(hostname=cfg.config["radio_ip"], connectNow=True)
 
@@ -141,12 +141,15 @@ init_radio()
 
 if cfg.config["use_discord"]:
     @client.event
-    async def on_ready():   
+    async def on_ready():
         logger.info("Logged in as {0.user} on Discord".format(client))
         #send_msg("ready")
 
     @client.event
     async def on_message(message):
+        if not cfg.config["permit_broadcast_of_discord_messages"]:
+            return
+
         global interface
         if message.author == client.user:
             return
@@ -164,7 +167,7 @@ if cfg.config["use_discord"]:
                     channel_index = cfg.config["secondary_channel_message_ids"].index(message.channel.id) + 1
                 else:
                     channel_index = cfg.config["send_channel_index"]
-                
+
                 if len(final_message) < cfg.config["max_message_length"] - 1:
                     await message.reply(final_message)
                     interface.sendText(final_message, channelIndex=channel_index)
@@ -175,7 +178,7 @@ if cfg.config["use_discord"]:
                     interface.sendText(short_msg, channelIndex=channel_index)
                     logger.infodiscord(short_msg)
                 #await message.delete()
-                
+
             else:
                 return
 

--- a/plugins/libdiscordutil.py
+++ b/plugins/libdiscordutil.py
@@ -24,7 +24,7 @@ def genUserName(interface, packet, details=True):
         ret += " `MQTT`"
 
     return ret
-    
+
 def send_msg(message,client,config,channel_id=0):
     if config["use_discord"]:
         if (client.is_ready()):


### PR DESCRIPTION
# Description
By enabling the `permit_broadcast_of_discord_messages` configuration option you are indicating that you will allow Discord users' messages that begin with the `discord_prefix` to be broadcasted via the linked Meshtastic node.

Conversely, if it's disabled then the flow of Discord -> Meshtastic messages will cease.

# Summary of Changes
- Addition of a `permit_broadcast_of_discord_messages` config.yml option
   - If disabled, then the `on_message` handler triggered by Discord messages being sent will immediately exit without seeking to possibly transmit the message.